### PR TITLE
Fix backslash handling in settings dialog

### DIFF
--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -124,10 +124,10 @@ def open_settings_dialog(master):
         collect_existing_connects(starter.get("groups", []))
 
         def add_to_group_path(groups, folder_path, base):
-            if not folder_path or folder_path.strip() in ["/", "\"]:
+            if not folder_path or folder_path.strip() in ["/", "\\"]:
                 groups.append(base)
                 return
-            parts = folder_path.split("\") if "\" in folder_path else folder_path.split("/")
+            parts = folder_path.split("\\") if "\\" in folder_path else folder_path.split("/")
             current = groups
             for part in parts:
                 match = next((g for g in current if g["type"] == "group" and g["name"] == part), None)


### PR DESCRIPTION
## Summary
- Correct path root detection for Windows by properly escaping backslash
- Fix folder path splitting logic for Windows paths

## Testing
- `python -m py_compile settings_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_6897029d6390832e8132ab70d6a8a5bd